### PR TITLE
check_dns is provided by nagios-plugins

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -1,5 +1,5 @@
 # Check a DNS server
 define command {
        command_name     check_dns
-       command_line     $PLUGINSDIR$/check_dns -H $_HOSTDNSHOSTNAME$ -a $_HOSTDNSEXPECTEDRESULT$ -s $HOSTADDRESS$
+       command_line     $NAGIOSPLUGINSDIR$/check_dns -H $_HOSTDNSHOSTNAME$ -a $_HOSTDNSEXPECTEDRESULT$ -s $HOSTADDRESS$
 }


### PR DESCRIPTION
nagios-plugins are installed in /usr/lib/nagios/plugins and that's where the check_dns binary is.
